### PR TITLE
[tiny] Update dependency to new package location

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "docs": "jsdoc2md -t jsdoc2md/README.hbs src/*.js > README.md; echo"
   },
   "dependencies": {
-    "url-search-params": "^1.1.0"
+    "@ungap/url-search-params": "^0.1.2"
   },
   "devDependencies": {
     "babel": "^6.23.0",

--- a/src/url-search-params.js
+++ b/src/url-search-params.js
@@ -1,6 +1,6 @@
 let URLSearchParams = (typeof window !== 'undefined') && window.URLSearchParams;
 if (!URLSearchParams) {
-  URLSearchParams = require('url-search-params');
+  URLSearchParams = require('@ungap/url-search-params');
 }
 
 module.exports = URLSearchParams;

--- a/tests/url-search-params.native.spec.js
+++ b/tests/url-search-params.native.spec.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-new */
 
 const nativeSpy = jest.spyOn(global, 'URLSearchParams');
-const ponyfill = require('url-search-params');
-jest.mock('url-search-params');
+const ponyfill = require('@ungap/url-search-params');
+jest.mock('@ungap/url-search-params');
 const URLSearchParams = require('../src/url-search-params');
 
 describe('URLSearchParams', () => {

--- a/tests/url-search-params.ponyfill.spec.js
+++ b/tests/url-search-params.ponyfill.spec.js
@@ -3,8 +3,8 @@
  */
 /* eslint-disable no-new */
 
-const ponyfill = require('url-search-params');
-jest.mock('url-search-params');
+const ponyfill = require('@ungap/url-search-params');
+jest.mock('@ungap/url-search-params');
 const URLSearchParams = require('../src/url-search-params');
 
 describe('URLSearchParams', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@ungap/url-search-params@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@ungap/url-search-params/-/url-search-params-0.1.2.tgz#8ba8c0527543fe675d1c29ae0a2daca842e8ee4f"
+  integrity sha512-WVk5+lJ+AoNLh2sIDMhnEAgLsVQuI067hWLJCzirErH1GYiy1gs09q4+XZxYWSvdAsslKsaO4q1iXXMx2c72dA==
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -4408,10 +4413,6 @@ uri-js@^4.2.2:
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
-
-url-search-params@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/url-search-params/-/url-search-params-1.1.0.tgz#865669a6e4e9e5543f86fc972b27c91485375326"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
The package now reside at https://github.com/ungap/url-search-params 

npm: https://www.npmjs.com/package/@ungap/url-search-params